### PR TITLE
refector: 허브 도메인 Entity, Repository 개선

### DIFF
--- a/hub/src/main/java/com/business/hub/domain/entity/Hub.java
+++ b/hub/src/main/java/com/business/hub/domain/entity/Hub.java
@@ -6,14 +6,12 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-
 @Getter
-@SuperBuilder
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "p_hubs")
@@ -39,11 +37,29 @@ public class Hub extends BaseDataEntity {
     @Column(name = "hub_manager_id", nullable = false)
     private UUID hubManagerId;
 
-
     @OneToMany(mappedBy = "departureHub")
     private List<HubMovement> departureMovements = new ArrayList<>();
 
     @OneToMany(mappedBy = "arrivalHub")
     private List<HubMovement> arrivalMovements = new ArrayList<>();
 
+    @Builder
+    public static Hub create(
+            LocalDateTime createdAt,
+            Long createdBy,
+            String hubName,
+            String hubAddress,
+            BigDecimal hubLatitude,
+            BigDecimal hubLongitude,
+            UUID hubManagerId) {
+        return Hub.builder()
+                .createdAt(createdAt)
+                .createdBy(createdBy)
+                .hubName(hubName)
+                .hubAddress(hubAddress)
+                .hubLatitude(hubLatitude)
+                .hubLongitude(hubLongitude)
+                .hubManagerId(hubManagerId)
+                .build();
+    }
 }

--- a/hub/src/main/java/com/business/hub/domain/entity/HubMovement.java
+++ b/hub/src/main/java/com/business/hub/domain/entity/HubMovement.java
@@ -10,10 +10,9 @@ import java.util.UUID;
 
 @Getter
 @SuperBuilder
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@Table(name = "p_hub_monvements")
+@Table(name = "p_hub_movements")
 public class HubMovement extends BaseDataEntity {
 
     @Id
@@ -21,19 +20,32 @@ public class HubMovement extends BaseDataEntity {
     @Column(name = "hub_movement_id")
     private UUID movementId;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "departure_hub_id", nullable = false)
     private Hub departureHub;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "arrival_hub_id", nullable = false)
     private Hub arrivalHub;
 
     @Column(name = "duration_time", nullable = false)
     private int durationTime;
 
-    @Column(name = "distance", nullable = false)
+    @Column(name = "distance", nullable = false, precision = 10, scale = 2)
     private BigDecimal distance;
 
-
+    public static HubMovement create(
+            Hub departureHub,
+            Hub arrivalHub,
+            int durationTime,
+            BigDecimal distance,
+            Long createdBy) {
+        return HubMovement.builder()
+                .departureHub(departureHub)
+                .arrivalHub(arrivalHub)
+                .durationTime(durationTime)
+                .distance(distance)
+                .createdBy(createdBy)
+                .build();
+    }
 }

--- a/hub/src/main/java/com/business/hub/domain/repository/HubMovementRepository.java
+++ b/hub/src/main/java/com/business/hub/domain/repository/HubMovementRepository.java
@@ -5,7 +5,6 @@ import org.springframework.stereotype.Repository;
 
 
 @Repository
-
 public interface HubMovementRepository{
     void save(HubMovement hubMovement);
 }

--- a/hub/src/main/java/com/business/hub/domain/repository/HubRepository.java
+++ b/hub/src/main/java/com/business/hub/domain/repository/HubRepository.java
@@ -1,14 +1,21 @@
 package com.business.hub.domain.repository;
 
 import com.business.hub.domain.entity.Hub;
+
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface HubRepository extends JpaRepository<Hub, UUID> {
-
+public interface HubRepository{
+  Hub save(Hub hub);
   boolean existsByHubId(UUID hubId);
   boolean existsByHubName(String hubName);
+
+  Optional<Hub> findById(UUID departureHubId);
+
+  List<Hub> findAll();
 }
 

--- a/hub/src/main/java/com/business/hub/domain/repository/HubRepository.java
+++ b/hub/src/main/java/com/business/hub/domain/repository/HubRepository.java
@@ -8,14 +8,18 @@ import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-@Repository
+
 public interface HubRepository{
   Hub save(Hub hub);
+
   boolean existsByHubId(UUID hubId);
+
   boolean existsByHubName(String hubName);
 
   Optional<Hub> findById(UUID departureHubId);
 
   List<Hub> findAll();
+
+  boolean existsByHubNameAndHubAddress(String hubName, String hubAddress);
 }
 

--- a/hub/src/main/java/com/business/hub/infrastructure/repository/HubJpaRepository.java
+++ b/hub/src/main/java/com/business/hub/infrastructure/repository/HubJpaRepository.java
@@ -1,11 +1,11 @@
 package com.business.hub.infrastructure.repository;
 
-import com.business.hub.domain.entity.HubMovement;
+import com.business.hub.domain.entity.Hub;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.UUID;
 
 @Repository
-public interface HubMovementJpaRepository extends JpaRepository<HubMovement, UUID> {
+public interface HubJpaRepository extends JpaRepository<Hub, UUID> {
 }

--- a/hub/src/main/java/com/business/hub/infrastructure/repository/HubJpaRepository.java
+++ b/hub/src/main/java/com/business/hub/infrastructure/repository/HubJpaRepository.java
@@ -4,8 +4,17 @@ import com.business.hub.domain.entity.Hub;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface HubJpaRepository extends JpaRepository<Hub, UUID> {
+
+    boolean existsByHubId(UUID hubId);
+
+    boolean existsByHubName(String hubName);
+
+    boolean existsByHubNameAndHubAddress(String hubName, String hubAddress);
+
+    Optional<Hub> findById(UUID hubId);
 }

--- a/hub/src/main/java/com/business/hub/infrastructure/repository/HubMovementRepositoryImpl.java
+++ b/hub/src/main/java/com/business/hub/infrastructure/repository/HubMovementRepositoryImpl.java
@@ -3,7 +3,6 @@ package com.business.hub.infrastructure.repository;
 import com.business.hub.domain.entity.HubMovement;
 import com.business.hub.domain.repository.HubMovementRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -11,7 +10,6 @@ import org.springframework.stereotype.Repository;
 public class HubMovementRepositoryImpl implements HubMovementRepository {
 
     private final HubMovementJpaRepository hubMovementJpaRepository;
-
 
     @Override
     public void save(HubMovement hubMovement) {

--- a/hub/src/main/java/com/business/hub/infrastructure/repository/HubRepositoryImpl.java
+++ b/hub/src/main/java/com/business/hub/infrastructure/repository/HubRepositoryImpl.java
@@ -13,30 +13,35 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class HubRepositoryImpl implements HubRepository {
 
-    private final HubRepository hubRepository;
+    private final HubJpaRepository hubJpaRepository;
 
     @Override
     public Hub save(Hub hub) {
-        return hubRepository.save(hub);
+        return hubJpaRepository.save(hub);
     }
 
     @Override
     public boolean existsByHubId(UUID hubId) {
-        return hubRepository.existsByHubId(hubId);
+        return hubJpaRepository.existsByHubId(hubId);
     }
 
     @Override
     public boolean existsByHubName(String hubName) {
-        return hubRepository.existsByHubName(hubName);
+        return hubJpaRepository.existsByHubName(hubName);
     }
 
     @Override
     public Optional<Hub> findById(UUID departureHubId) {
-        return Optional.empty();
+        return hubJpaRepository.findById(departureHubId);
     }
 
     @Override
     public List<Hub> findAll() {
-        return hubRepository.findAll();
+        return hubJpaRepository.findAll();
+    }
+
+    @Override
+    public boolean existsByHubNameAndHubAddress(String hubName, String hubAddress) {
+        return hubJpaRepository.existsByHubNameAndHubAddress(hubName, hubAddress);
     }
 }

--- a/hub/src/main/java/com/business/hub/infrastructure/repository/HubRepositoryImpl.java
+++ b/hub/src/main/java/com/business/hub/infrastructure/repository/HubRepositoryImpl.java
@@ -1,4 +1,42 @@
 package com.business.hub.infrastructure.repository;
 
-public class HubRepositoryImpl {
+import com.business.hub.domain.entity.Hub;
+import com.business.hub.domain.repository.HubRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class HubRepositoryImpl implements HubRepository {
+
+    private final HubRepository hubRepository;
+
+    @Override
+    public Hub save(Hub hub) {
+        return hubRepository.save(hub);
+    }
+
+    @Override
+    public boolean existsByHubId(UUID hubId) {
+        return hubRepository.existsByHubId(hubId);
+    }
+
+    @Override
+    public boolean existsByHubName(String hubName) {
+        return hubRepository.existsByHubName(hubName);
+    }
+
+    @Override
+    public Optional<Hub> findById(UUID departureHubId) {
+        return Optional.empty();
+    }
+
+    @Override
+    public List<Hub> findAll() {
+        return hubRepository.findAll();
+    }
 }


### PR DESCRIPTION

## 개요
- @Builder를 정적 팩토리 메서드(create) 위로 이동하여 객체 생성 방식 명확화
- HubRepository와 HubJpaRepository를 분리하여 도메인과 인프라 계층 구분
- HubMovementRepositry와 HubMovementJpaRepository를 분리

<br>

## 📝 작업 내용
### 변경 사항
1. `@Builder` 위치 변경  

2. JPA 의존성 제거 

### 변경 이유

MyBatis 등 다양한 데이터 접근 방식을 고려하여 확장성을 높이기 위해,  
도메인 계층에서는 JPA와의 강한 결합을 피하고,  
JPA 관련 코드를 Infrastructure 계층에서 관리하도록 변경했습니다.

### 추가 설명

<br>

### 💬리뷰 요구사항

<br>

### #️⃣ 연관된 이슈
closed #108 

<br>

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

<br>

## ✅ Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
