### PR TITLE
bugfix: 오더 객체 무한루프 개선

### DIFF
--- a/order/src/main/java/com/business/order/application/dto/request/OrderItemRequestDto.java
+++ b/order/src/main/java/com/business/order/application/dto/request/OrderItemRequestDto.java
@@ -13,6 +13,6 @@ import java.util.UUID;
 @AllArgsConstructor
 public class OrderItemRequestDto {
     private UUID productId;
+    private UUID supplierId;
     private Integer orderItemAmount;
-    private Integer orderItemPrice;
 }

--- a/order/src/main/java/com/business/order/application/dto/response/OrderCreateResponseDto.java
+++ b/order/src/main/java/com/business/order/application/dto/response/OrderCreateResponseDto.java
@@ -18,8 +18,7 @@ public class OrderCreateResponseDto {
     private UUID receiverId;
     private String deliveryAddress;
     private Integer totalPrice;
-    private List<OrderItemResponseDto> orderItems;
-    private UUID supplierId;
     private UUID deliveryId;
+    private List<OrderItemResponseDto> orderItems;
 
 }

--- a/order/src/main/java/com/business/order/application/dto/response/OrderItemResponseDto.java
+++ b/order/src/main/java/com/business/order/application/dto/response/OrderItemResponseDto.java
@@ -12,8 +12,9 @@ import java.util.UUID;
 @AllArgsConstructor
 @Builder
 public class OrderItemResponseDto {
-    private UUID itemId;
+    private UUID orderItemId;
     private Integer orderItemAmount;
     private Long orderItemPrice;
     private UUID productId;
+    private UUID supplierId;
 }

--- a/order/src/main/java/com/business/order/application/mapper/OrderMapper.java
+++ b/order/src/main/java/com/business/order/application/mapper/OrderMapper.java
@@ -10,7 +10,6 @@ import java.util.stream.Collectors;
 
 public class OrderMapper {
 
-    //주문 엔티티 > 주문 생성 응답 DTO 변환
     public static OrderCreateResponseDto toOrderCreateResponseDto(Order order, List<OrderItem> orderItems) {
         return OrderCreateResponseDto.builder()
                 .orderId(order.getOrderId())
@@ -21,7 +20,6 @@ public class OrderMapper {
                 .build();
     }
 
-    //주문 아이템 리스트 변환
     private static List<OrderItemResponseDto> toOrderItemResponseList(List<OrderItem> orderItems) {
         return orderItems.stream()
                 .map(OrderMapper::toOrderItemResponse)
@@ -30,9 +28,11 @@ public class OrderMapper {
 
     private static OrderItemResponseDto toOrderItemResponse(OrderItem item) {
         return OrderItemResponseDto.builder()
-                .itemId(item.getOrderItemId())
+                .orderItemId(item.getOrderItemId())
                 .orderItemAmount(item.getOrderItemAmount())
                 .orderItemPrice(item.getOrderItemPrice())
+                .productId(item.getProductId())
+                .supplierId(item.getSupplierId())
                 .build();
     }
 }

--- a/order/src/main/java/com/business/order/application/service/OrderService.java
+++ b/order/src/main/java/com/business/order/application/service/OrderService.java
@@ -8,6 +8,7 @@ import com.business.order.domain.entity.OrderItem;
 import com.business.order.domain.repository.OrderItemRepository;
 import com.business.order.domain.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +16,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class OrderService {
@@ -22,18 +24,13 @@ public class OrderService {
     private final OrderRepository orderRepository;
     private final OrderItemRepository orderItemRepository;
 
-    //주문 생성 (외부 서비스 없이 내부 로직만)
     @Transactional
     public OrderCreateResponseDto createOrder(OrderCreateRequestDto request, Long userId){
 
-        //상품 서비스에서 productId 기반으로 supplierId 조회 (현재는 더미 데이터)
-        UUID supplierId = UUID.fromString("00000000-0000-0000-0000-000000000000");
 
-        //허브 서비스에서 supplierId, receiverId 기반으로 hubId 조회 (현재는 더미 데이터)
         UUID originHubId = UUID.fromString("00000000-0000-0000-0000-000000000001");
         UUID destinationHubId = UUID.fromString("00000000-0000-0000-0000-000000000002");
 
-        //주문 생성
         Order order = Order.create(
                 userId,
                 request.getReceiverId(),
@@ -44,20 +41,21 @@ public class OrderService {
         );
         Order savedOrder  = orderRepository.save(order);
 
-        //주문 아이템 생성(상품 가격 더미 데이터 활용)
+        UUID supplierId = UUID.fromString("00000000-0000-0000-0000-000000000000");
+
         List<OrderItem> orderItems = request.getItems().stream()
                 .map(item -> OrderItem.create(
                         savedOrder,
                         item.getProductId(),
+                        supplierId,
                         item.getOrderItemAmount(),
                         10000L
                 ))
                 .collect(Collectors.toList());
 
         savedOrder.addOrderItems(orderItems);
-        List<OrderItem> saveOrderItems = orderItemRepository.saveAll(orderItems);
 
-        return OrderMapper.toOrderCreateResponseDto(savedOrder, saveOrderItems);
+        return OrderMapper.toOrderCreateResponseDto(savedOrder, orderItems);
     }
 
 }

--- a/order/src/main/java/com/business/order/domain/entity/Order.java
+++ b/order/src/main/java/com/business/order/domain/entity/Order.java
@@ -1,18 +1,19 @@
 package com.business.order.domain.entity;
 
-import com.business.common.domain.entity.BaseDataEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+@Slf4j
 @Entity
 @Table(name = "p_orders")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Order extends BaseDataEntity {
+public class Order{
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -44,6 +45,16 @@ public class Order extends BaseDataEntity {
     private List<OrderItem> orderItems = new ArrayList<>();
 
     @Builder
+    public Order(Long userId, UUID receiverId, String deliveryAddress,
+                  UUID originHubId, UUID destinationHubId, Integer totalPrice) {
+        this.userId = userId;
+        this.receiverId = receiverId;
+        this.deliveryAddress = deliveryAddress;
+        this.originHubId = originHubId;
+        this.destinationHubId = destinationHubId;
+        this.totalPrice = totalPrice;
+    }
+
     public static Order create(Long userId, UUID receiverId, String deliveryAddress,
                                UUID originHubId, UUID destinationHubId, Integer totalPrice) {
         return Order.builder()

--- a/order/src/main/java/com/business/order/domain/entity/OrderItem.java
+++ b/order/src/main/java/com/business/order/domain/entity/OrderItem.java
@@ -1,20 +1,21 @@
 package com.business.order.domain.entity;
 
-import com.business.common.domain.entity.BaseDataEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.UUID;
 
+@Slf4j
 @Entity
 @Table(name = "p_order_items")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class OrderItem extends BaseDataEntity {
+public class OrderItem {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
-    @Column(name = "order_item_id", updatable = false, nullable = false)
+    @Column(name = "order_item_id")
     private UUID orderItemId;
 
     @Column(name = "product_id", nullable = false)
@@ -34,10 +35,21 @@ public class OrderItem extends BaseDataEntity {
     private Order order;
 
     @Builder
-    public static OrderItem create(Order order, UUID productId, Integer orderItemAmount, Long orderItemPrice) {
+    public OrderItem(Order order, UUID productId, UUID supplierId, Integer orderItemAmount,
+                      Long orderItemPrice) {
+        this.order = order;
+        this.productId = productId;
+        this.supplierId = supplierId;
+        this.orderItemAmount = orderItemAmount;
+        this.orderItemPrice = orderItemPrice;
+    }
+
+    public static OrderItem create(Order order, UUID productId, UUID supplierId,
+                                   Integer orderItemAmount, Long orderItemPrice) {
         return OrderItem.builder()
                 .order(order)
                 .productId(productId)
+                .supplierId(supplierId)
                 .orderItemAmount(orderItemAmount)
                 .orderItemPrice(orderItemPrice)
                 .build();


### PR DESCRIPTION
## 개요
- 기존 create() 메서드에서 @builder를 사용하여 OrderItem.builder()를 직접 호출하는 방식으로 인해 무한 루프가 발생합니다. 이를 해결하기 위해 생성자를 명시적으로 추가하여 OrderItem 객체가 정상적으로 생성되도록 수정했으며, create() 메서드에서 @builder가 적용된 생성자를 호출하도록 변경하여 무한 루프 방지했습니다.

<br>

## 📝 작업 내용
### 변경 사항
- dto 값 이동 : 사용자 관점에서 봤을때 오더 아이템마다 공급업체의 정보를 보여주고자 오더 > 오더 아이템으로 이동
- OrderItemRepository 삭제 : 주문-주문 아이템의 생애주기는 동일하므로 동시에 생성되며 삭제된다. 따라서 주문아이템은 별도로 레파지토리를 가지지 않는다.
- 기존 create() 메서드에서 @builder를 사용 > 생성자를 명시적으로 추가하였으며, create() 메서드에서 @builder가 적용된 생성자를 호출하도록 변경

### 변경 이유

### 추가 설명

<br>

### 💬리뷰 요구사항

<br>

### #️⃣ 연관된 이슈
closed #113

<br>

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

<br>

## ✅ Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
