### PR TITLE
fix: DeliveryJpaRepository의 불필요한 custom save() 제거

### DIFF
--- a/delivery/src/main/java/com/business/delivery/infrastructure/repository/DeliveryJpaRepository.java
+++ b/delivery/src/main/java/com/business/delivery/infrastructure/repository/DeliveryJpaRepository.java
@@ -6,5 +6,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DeliveryJpaRepository extends JpaRepository<Delivery, UUID> {
 
-  Delivery save();
 }

--- a/delivery/src/main/java/com/business/delivery/infrastructure/repository/DeliveryRepositoryImpl.java
+++ b/delivery/src/main/java/com/business/delivery/infrastructure/repository/DeliveryRepositoryImpl.java
@@ -13,6 +13,6 @@ public class DeliveryRepositoryImpl implements DeliveryRepository {
 
   @Override
   public Delivery save(Delivery delivery) {
-    return deliveryJpaRepository.save();
-    }
+    return deliveryJpaRepository.save(delivery);
   }
+}


### PR DESCRIPTION
## 개요
중복 에러 해결

<br>

## 📝 작업 내용
### 변경 사항
- DeliveryJpaRepository에서 별도로 선언한 save() 메서드 제거
  - JpaRepository가 이미 save(Delivery delivery) 메서드를 제공하고 있어 중복 선언으로 인해 쿼리 생성 오류가 발생
- DeliveryRepositoryImpl에서는 이제 JpaRepository의 기본 save() 메서드를 호출하며, delivery 인자를 전달하도록 수정

### 변경 이유

### 추가 설명

<br>

### 💬리뷰 요구사항

<br>

### #️⃣ 연관된 이슈
closed #170

<br>

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

<br>

## ✅ Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
