### PR TITLE
Feat: 배송 및 배송 담당자 취소 API 구현

### DIFF
--- a/delivery/src/main/java/com/business/delivery/application/exception/DeliveryErrorCode.java
+++ b/delivery/src/main/java/com/business/delivery/application/exception/DeliveryErrorCode.java
@@ -14,7 +14,7 @@ public enum DeliveryErrorCode implements ExceptionCode {
   DELIVERY_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 배송입니다."),
 
   // 배송 경로
-  ROUTE_NOT_FOUND(HttpStatus.NOT_FOUND, "배송 경로를 찾을 수 없습니다."),
+  DELIVERY_ROUTE_NOT_FOUND(HttpStatus.NOT_FOUND, "배송 경로를 찾을 수 없습니다."),
   INVALID_ROUTE_SEQUENCE(HttpStatus.BAD_REQUEST, "배송 경로 순서가 올바르지 않습니다."),
   DUPLICATE_DELIVERY_ROUTE(HttpStatus.CONFLICT, "이미 존재하는 배송 경로입니다."),
   INVALID_DELIVERY_STATUS(HttpStatus.BAD_REQUEST, "배송 상태가 올바르지 않습니다."),
@@ -23,7 +23,8 @@ public enum DeliveryErrorCode implements ExceptionCode {
   // 외부 API
   HUB_MOVEMENT_NOT_AVAILABLE(HttpStatus.NOT_FOUND, "허브 간 이동 정보를 가져올 수 없습니다."),
   HUB_COORDINATE_NOT_AVAILABLE(HttpStatus.NOT_FOUND, "허브 좌표 정보를 가져올 수 없습니다."),
-  NAVER_API_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "네이버 API 호출 중 오류가 발생했습니다.");
+  NAVER_API_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "네이버 API 호출 중 오류가 발생했습니다."),
+  DRIVER_CANCEL_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "배송 담당자 취소 서비스와의 통신 중 오류가 발생했습니다.");
 
 
   private final HttpStatus status;

--- a/delivery/src/main/java/com/business/delivery/application/service/DeliveryService.java
+++ b/delivery/src/main/java/com/business/delivery/application/service/DeliveryService.java
@@ -2,11 +2,6 @@ package com.business.delivery.application.service;
 
 import com.business.common.application.exception.BusinessLogicException;
 import com.business.common.infrastructure.api.NaverApiService;
-import com.business.common.infrastructure.config.QueryDSLConfig;
-import com.business.common.infrastructure.util.CommonUtil;
-import com.business.common.infrastructure.util.JpaUtil;
-import com.business.common.infrastructure.util.QueryDslUtil;
-import com.business.delivery.DeliveryApplication;
 import com.business.delivery.application.dto.mapper.DeliveryResponseMapper;
 import com.business.delivery.application.dto.mapper.DeliveryRequestMapper;
 import com.business.delivery.application.dto.request.CreateDeliveryRequestDto;
@@ -128,5 +123,27 @@ public class DeliveryService {
     public void deleteByDeliveryId(UUID deliveryId, Long deletedBy) {
 
         deliveryRepository.deleteByDeliveryId(deliveryId, deletedBy);
+    }
+
+    @Transactional
+    public void cancelDelivery(UUID deliveryId) {
+
+        Delivery delivery = deliveryRepository.findByDeliveryId(deliveryId);
+
+        delivery.updateCancelStatus();
+
+        deliveryRepository.save(delivery);
+
+        UUID deliveryRouteId = delivery.getDeliveryRoutes().stream()
+            .filter(route -> route.getDeliveryRouteId() != null)
+            .findFirst()
+            .map(DeliveryRoute::getDeliveryRouteId)
+            .orElseThrow(() -> new BusinessLogicException(DeliveryErrorCode.DELIVERY_ROUTE_NOT_FOUND));
+
+        try {
+            userClient.cancelDriverStatus(deliveryRouteId);
+        } catch (Exception e) {
+            throw new BusinessLogicException(DeliveryErrorCode.DRIVER_CANCEL_ERROR);
+        }
     }
 }

--- a/delivery/src/main/java/com/business/delivery/domain/entity/Delivery.java
+++ b/delivery/src/main/java/com/business/delivery/domain/entity/Delivery.java
@@ -110,5 +110,13 @@ public class Delivery extends BaseDataEntity {
   public void softDelete(Long userId) {
     this.deletedBy(userId);
   }
+
+  public void updateCancelStatus() {
+
+    this.deliveryStatus = DeliveryStatus.CANCELED;
+    for (DeliveryRoute route : deliveryRoutes) {
+      route.updateCancelStatus();
+      }
+  }
 }
 

--- a/delivery/src/main/java/com/business/delivery/domain/entity/DeliveryRoute.java
+++ b/delivery/src/main/java/com/business/delivery/domain/entity/DeliveryRoute.java
@@ -105,4 +105,9 @@ public class DeliveryRoute extends BaseDataEntity {
   public void associateDelivery(Delivery delivery) {
       this.delivery = delivery;
   }
+
+  public void updateCancelStatus() {
+
+    this.deliveryRouteStatus = DeliveryRouteStatus.CANCELED;
+  }
 }

--- a/delivery/src/main/java/com/business/delivery/domain/entity/DeliveryRouteStatus.java
+++ b/delivery/src/main/java/com/business/delivery/domain/entity/DeliveryRouteStatus.java
@@ -3,7 +3,6 @@ package com.business.delivery.domain.entity;
 public enum DeliveryRouteStatus {
 
   CANCELED,
-  WAITING_AT_HUB,
   IN_TRANSIT_TO_HUB,
   ARRIVED_AT_HUB,
   OUT_FOR_DELIVERY,

--- a/delivery/src/main/java/com/business/delivery/domain/entity/DeliveryStatus.java
+++ b/delivery/src/main/java/com/business/delivery/domain/entity/DeliveryStatus.java
@@ -4,8 +4,6 @@ public enum DeliveryStatus {
 
   CANCELED,
   WAITING_AT_HUB,
-  IN_TRANSIT_TO_HUB,
-  ARRIVED_AT_HUB,
   OUT_FOR_DELIVERY,
   DELIVERED
 }

--- a/delivery/src/main/java/com/business/delivery/infrastructure/client/UserClient.java
+++ b/delivery/src/main/java/com/business/delivery/infrastructure/client/UserClient.java
@@ -9,4 +9,7 @@ public interface UserClient {
 
   @PostMapping("/api/v1/delivery-drivers/assign")
   Long assignDeliveryDriver(@RequestParam("delivery_id") UUID deliveryId);
+
+  @PutMapping("/api/v1/delivery-drivers/{deliveryRouteId}/cancel")
+  void cancelDriverStatus(@PathVariable("deliveryRouteId") UUID deliveryRouteId);
 }

--- a/delivery/src/main/java/com/business/delivery/presentation/controller/DeliveryController.java
+++ b/delivery/src/main/java/com/business/delivery/presentation/controller/DeliveryController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -47,17 +48,24 @@ public class DeliveryController {
     }
 
     @GetMapping("/{deliveryId}")
-    public ResponseEntity<DeliveryDetailResponseDto> getDeliveryDetail(@PathVariable UUID deliveryId) {
+    public ResponseEntity<DeliveryDetailResponseDto> getDeliveryDetail(@PathVariable("deliveryId") UUID deliveryId) {
 
         DeliveryDetailResponseDto response = deliveryService.getDeliveryByDeliveryId(deliveryId);
         return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/{deliveryId}")
-    public ResponseEntity<Void> deleteByDeliveryId(@PathVariable UUID deliveryId,
+    public ResponseEntity<Void> deleteByDeliveryId(@PathVariable("deliveryId") UUID deliveryId,
         @RequestParam Long deletedBy) {
 
         deliveryService.deleteByDeliveryId(deliveryId, deletedBy);
         return ResponseEntity.noContent().build();
+    }
+
+    @PutMapping("/{deliveryId}/cancel")
+    public ResponseEntity<Void> cancelDelivery(@PathVariable("deliveryId") UUID deliveryId) {
+
+        deliveryService.cancelDelivery(deliveryId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/delivery/src/test/java/com/business/delivery/application/service/DeliveryServiceTest.java
+++ b/delivery/src/test/java/com/business/delivery/application/service/DeliveryServiceTest.java
@@ -1,0 +1,153 @@
+package com.business.delivery.application.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import com.business.common.application.exception.BusinessLogicException;
+import com.business.delivery.domain.entity.Delivery;
+import com.business.delivery.domain.entity.DeliveryRoute;
+import com.business.delivery.domain.entity.DeliveryRouteStatus;
+import com.business.delivery.domain.entity.DeliveryStatus;
+import com.business.delivery.domain.repository.DeliveryRepository;
+import com.business.delivery.infrastructure.client.UserClient;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith(MockitoExtension.class)
+class DeliveryServiceTest {
+
+  @Mock
+  private DeliveryRepository deliveryRepository;
+
+  @Mock
+  private UserClient mockUserClient;
+
+  @InjectMocks
+  private DeliveryService deliveryService;
+
+  private UUID deliveryId;
+  private UUID routeId;
+  private Delivery delivery;
+  private DeliveryRoute deliveryRoute;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    deliveryId = UUID.randomUUID();
+    routeId = UUID.randomUUID();
+
+    // lenient stubbing: 불필요한 stubbing 경고를 피하기 위해 lenient() 사용
+    lenient().doNothing().when(mockUserClient).cancelDriverStatus(any(UUID.class));
+
+    // DeliveryRoute 인스턴스 생성 (Reflection 필요 없으면 Builder 사용)
+    deliveryRoute = DeliveryRoute.deliveryRouteCreateBuilder()
+        .delivery(null) // 나중에 Reflection으로 연결
+        .routeSequence(1L)
+        .originHubId(UUID.randomUUID())
+        .destinationHubId(UUID.randomUUID())
+        .estimatedDistance(BigDecimal.TEN)
+        .estimatedTime(10L)
+        .deliveryRouteStatus(DeliveryRouteStatus.WAITING_AT_HUB)
+        .deliveryAddress("Test Address")
+        .build();
+
+    // Reflection으로 deliveryRouteId 설정
+    Field routeIdField = DeliveryRoute.class.getDeclaredField("deliveryRouteId");
+    routeIdField.setAccessible(true);
+    routeIdField.set(deliveryRoute, routeId);
+
+    // ===== Delivery 인스턴스 생성 (protected 생성자) =====
+    delivery = createDeliveryInstance();
+
+    // DeliveryStatus 초기값: WAITING_AT_HUB
+    setDeliveryStatus(delivery, DeliveryStatus.WAITING_AT_HUB);
+
+    // deliveryRoutes 필드에 1개의 route를 설정
+    setDeliveryRoutes(delivery, List.of(deliveryRoute));
+
+    // deliveryRoute와 delivery 연결 (양방향 관계 시 필요)
+    associateRouteWithDelivery(deliveryRoute, delivery);
+  }
+
+  @Test
+  void cancelDelivery_Success() throws Exception {
+    // given
+    when(deliveryRepository.findByDeliveryId(deliveryId)).thenReturn(delivery);
+
+    // when
+    deliveryService.cancelDelivery(deliveryId);
+
+    // then
+    // 1) Delivery 상태가 CANCELED로 바뀌었는지 확인
+    assertEquals(DeliveryStatus.CANCELED, getDeliveryStatus(delivery));
+
+    // 2) DeliveryRoute 상태가 CANCELED로 바뀌었는지 확인
+    assertEquals(DeliveryRouteStatus.CANCELED, deliveryRoute.getDeliveryRouteStatus());
+
+    // 3) MockUserClient가 cancelDriverStatus(routeId)를 호출했는지 확인
+    verify(mockUserClient, times(1)).cancelDriverStatus(routeId);
+  }
+
+  @Test
+  void cancelDelivery_WhenNoAssignedRoute_ThrowsException() throws Exception {
+    // given
+    // deliveryRoutes를 빈 리스트로 세팅
+    setDeliveryRoutes(delivery, Collections.emptyList());
+    when(deliveryRepository.findByDeliveryId(deliveryId)).thenReturn(delivery);
+
+    // when & then
+    BusinessLogicException ex = assertThrows(BusinessLogicException.class,
+        () -> deliveryService.cancelDelivery(deliveryId)
+    );
+    // 여기서는 예외 발생 여부만 확인합니다.
+  }
+
+  // ===== 아래는 Reflection 헬퍼 메서드들 =====
+
+  // protected 생성자인 Delivery 인스턴스를 Reflection으로 생성
+  private Delivery createDeliveryInstance() throws Exception {
+    Class<Delivery> clazz = Delivery.class;
+    Constructor<Delivery> cons = clazz.getDeclaredConstructor();
+    cons.setAccessible(true); // 접근 권한 허용
+    return cons.newInstance();
+  }
+
+  // Delivery 엔티티의 deliveryStatus 필드에 값을 주입
+  private void setDeliveryStatus(Delivery delivery, DeliveryStatus status) throws Exception {
+    Field statusField = Delivery.class.getDeclaredField("deliveryStatus");
+    statusField.setAccessible(true);
+    statusField.set(delivery, status);
+  }
+
+  // Delivery 엔티티의 deliveryRoutes 필드에 값을 주입
+  private void setDeliveryRoutes(Delivery delivery, List<DeliveryRoute> routes) throws Exception {
+    Field routesField = Delivery.class.getDeclaredField("deliveryRoutes");
+    routesField.setAccessible(true);
+    routesField.set(delivery, routes);
+  }
+
+  // DeliveryRoute와 Delivery를 연결 (양방향 매핑 시 필요)
+  private void associateRouteWithDelivery(DeliveryRoute route, Delivery delivery) throws Exception {
+    Field deliveryField = DeliveryRoute.class.getDeclaredField("delivery");
+    deliveryField.setAccessible(true);
+    deliveryField.set(route, delivery);
+  }
+
+  // Delivery 엔티티의 현재 상태를 Reflection으로 가져오기
+  private DeliveryStatus getDeliveryStatus(Delivery delivery) throws Exception {
+    Field statusField = Delivery.class.getDeclaredField("deliveryStatus");
+    statusField.setAccessible(true);
+    return (DeliveryStatus) statusField.get(delivery);
+  }
+}

--- a/delivery/src/test/java/com/business/delivery/infrastructure/client/MockUserClient.java
+++ b/delivery/src/test/java/com/business/delivery/infrastructure/client/MockUserClient.java
@@ -1,0 +1,8 @@
+package com.business.delivery.infrastructure.client;
+
+import java.util.UUID;
+
+public interface MockUserClient {
+
+    void cancelDriverStatus(UUID deliveryRouteId);
+}

--- a/user/src/main/java/com/business/user/deliverydriver/application/exception/DeliveryDriverErrorCode.java
+++ b/user/src/main/java/com/business/user/deliverydriver/application/exception/DeliveryDriverErrorCode.java
@@ -22,13 +22,12 @@ public enum DeliveryDriverErrorCode implements ExceptionCode {
   DELIVERY_ROUTE_NOT_FOUND(HttpStatus.NOT_FOUND, "배송 담당자에게 할당된 배송 경로 정보를 찾을 수 없습니다."),
   NO_AVAILABLE_DRIVER(HttpStatus.NOT_FOUND, "배정할 담당자가 없습니다."),
   DELIVERY_DRIVER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 배송 담당자입니다."),
+  DRIVER_CANCEL_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "배송 담당자 취소 상태 업데이트에 실패했습니다."),
 
   // 외부 API
   EXTERNAL_DELIVERY_NOT_FOUND(HttpStatus.NOT_FOUND, "외부 배송 정보를 찾을 수 없습니다."),
   EXTERNAL_DELIVERY_ROUTE_NOT_FOUND(HttpStatus.NOT_FOUND, "외부 배송 경로 정보를 찾을 수 없습니다."),
   EXTERNAL_HUB_NOT_FOUND(HttpStatus.NOT_FOUND, "외부 허브 정보를 찾을 수 없습니다.");
-
-
 
   private final HttpStatus status;
   private final String message;

--- a/user/src/main/java/com/business/user/deliverydriver/application/service/DeliveryDriverService.java
+++ b/user/src/main/java/com/business/user/deliverydriver/application/service/DeliveryDriverService.java
@@ -187,4 +187,15 @@ public class DeliveryDriverService {
             throw new BusinessLogicException(DeliveryDriverErrorCode.EXTERNAL_DELIVERY_ROUTE_NOT_FOUND);
         }
     }
+
+    @Transactional
+    public void cancelDriverStatus(UUID deliveryRouteId) {
+
+        DeliveryDriver driver = deliveryDriverRepository.findByDeliveryRouteId(deliveryRouteId)
+            .orElseThrow(() -> new BusinessLogicException(DeliveryDriverErrorCode.DRIVER_CANCEL_ERROR));
+
+        driver.updateCancelStatus();
+
+        deliveryDriverRepository.save(driver);
+    }
 }

--- a/user/src/main/java/com/business/user/deliverydriver/domain/entity/DeliveryDriver.java
+++ b/user/src/main/java/com/business/user/deliverydriver/domain/entity/DeliveryDriver.java
@@ -58,18 +58,26 @@ public class DeliveryDriver extends BaseDataEntity {
   @Comment("배정된 배송 경로 순서")
   private Long routeSequence;
 
-  private DeliveryDriver(Long userId, UUID hubId, UUID slackId, DriverType driverType, Long deliverySequence) {
+  @NotNull
+  @Column(nullable = false, length = 10)
+  @Enumerated(EnumType.STRING)
+  @Comment("배송 담당자 상태")
+  private DriverStatus driverStatus;
+
+  private DeliveryDriver(Long userId, UUID hubId, UUID slackId, DriverType driverType, Long deliverySequence, DriverStatus driverStatus) {
 
     this.deliveryDriverId = userId;
     this.hubId = hubId;
     this.slackId = slackId;
     this.driverType = driverType;
     this.deliverySequence = deliverySequence;
+    this.driverStatus = driverStatus;
   }
 
   @Builder(builderMethodName = "deliveryDriverCreateBuilder")
-  public static DeliveryDriver create(Long deliveryDriverId, UUID hubId, UUID slackId, DriverType driverType, Long deliverySequence) {
-    return new DeliveryDriver(deliveryDriverId, hubId, slackId, driverType, deliverySequence);
+  public static DeliveryDriver create(Long deliveryDriverId, UUID hubId, UUID slackId, DriverType driverType, Long deliverySequence, DriverStatus driverStatus) {
+
+    return new DeliveryDriver(deliveryDriverId, hubId, slackId, driverType, deliverySequence, driverStatus);
   }
 
   public void assignToRoute(UUID deliveryRouteId, Long routeSequence) {
@@ -81,6 +89,10 @@ public class DeliveryDriver extends BaseDataEntity {
 
   public void updateAssignAt(LocalDateTime assignAt) {
     this.assignAt = assignAt;
+  }
+
+  public void updateCancelStatus() {
+    this.driverStatus = DriverStatus.CANCELED;
   }
 }
 

--- a/user/src/main/java/com/business/user/deliverydriver/domain/entity/DriverStatus.java
+++ b/user/src/main/java/com/business/user/deliverydriver/domain/entity/DriverStatus.java
@@ -3,8 +3,8 @@ package com.business.user.deliverydriver.domain.entity;
 public enum DriverStatus {
 
     ASSIGNED,
-    HUB_IN_TRANSIT,
-    DELIVERING,
-    COMPLETED,
+    IN_TRANSIT_TO_HUB,
+    OUT_FOR_DELIVERY,
+    DELIVERED,
     CANCELED;
 }

--- a/user/src/main/java/com/business/user/deliverydriver/domain/entity/DriverStatus.java
+++ b/user/src/main/java/com/business/user/deliverydriver/domain/entity/DriverStatus.java
@@ -1,0 +1,10 @@
+package com.business.user.deliverydriver.domain.entity;
+
+public enum DriverStatus {
+
+    ASSIGNED,
+    HUB_IN_TRANSIT,
+    DELIVERING,
+    COMPLETED,
+    CANCELED;
+}

--- a/user/src/main/java/com/business/user/deliverydriver/domain/repository/DeliveryDriverRepository.java
+++ b/user/src/main/java/com/business/user/deliverydriver/domain/repository/DeliveryDriverRepository.java
@@ -23,4 +23,6 @@ public interface DeliveryDriverRepository {
     Optional<DeliveryDriver> findLastAssignedDriverByTypeAndHub(DriverType driverType, UUID hubId);
     Optional<DeliveryDriver> findNextAvailableDriverByTypeAndHub(Long currentSequence, DriverType driverType, UUID hubId);
     Page<DeliveryDriver> findDeliveryDrivers(DeliveryDriverSearchRequestDto request, Pageable pageable);
+    Optional<DeliveryDriver> findByDeliveryRouteId(UUID deliveryRouteId);
+
 }

--- a/user/src/main/java/com/business/user/deliverydriver/infrastructure/client/DeliveryClient.java
+++ b/user/src/main/java/com/business/user/deliverydriver/infrastructure/client/DeliveryClient.java
@@ -11,5 +11,5 @@ import org.springframework.web.bind.annotation.PathVariable;
 public interface DeliveryClient {
 
   @GetMapping("/api/v1/deliveries/{deliveryId}")
-  List<DeliveryClientResponseDto> getRoutesByDeliveryId(@PathVariable UUID deliveryId);
+  List<DeliveryClientResponseDto> getRoutesByDeliveryId(@PathVariable("deliveryId") UUID deliveryId);
 }

--- a/user/src/main/java/com/business/user/deliverydriver/infrastructure/repository/DeliveryDriverJpaRepository.java
+++ b/user/src/main/java/com/business/user/deliverydriver/infrastructure/repository/DeliveryDriverJpaRepository.java
@@ -33,4 +33,6 @@ public interface DeliveryDriverJpaRepository extends JpaRepository<DeliveryDrive
   boolean existsByDeliveryDriverIdAndDeletedAtIsNull(Long deliveryDriverId);
 
   Optional<DeliveryDriver> findByDeliveryDriverIdAndDeletedAtIsNull(Long deliveryDriverId);
+
+  Optional<DeliveryDriver> findByDeliveryRouteIdAndDeletedAtIsNull(UUID deliveryRouteId);
 }

--- a/user/src/main/java/com/business/user/deliverydriver/infrastructure/repository/DeliveryDriverRepositoryImpl.java
+++ b/user/src/main/java/com/business/user/deliverydriver/infrastructure/repository/DeliveryDriverRepositoryImpl.java
@@ -131,4 +131,9 @@ public class DeliveryDriverRepositoryImpl implements DeliveryDriverRepository {
 
         return PageableExecutionUtils.getPage(content, pageable, () -> total == null ? 0 : total);
     }
+
+    @Override
+    public Optional<DeliveryDriver> findByDeliveryRouteId(UUID deliveryRouteId) {
+        return deliveryDriverJpaRepository.findByDeliveryRouteIdAndDeletedAtIsNull(deliveryRouteId);
+    }
 }

--- a/user/src/main/java/com/business/user/deliverydriver/presentation/controller/DeliveryDriverController.java
+++ b/user/src/main/java/com/business/user/deliverydriver/presentation/controller/DeliveryDriverController.java
@@ -10,6 +10,7 @@ import com.business.user.deliverydriver.application.dto.response.DeliveryDriverL
 import com.business.user.deliverydriver.application.dto.response.DeliveryDriverResponseDto;
 import com.business.user.deliverydriver.application.service.DeliveryDriverService;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -17,6 +18,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -55,6 +57,13 @@ public class DeliveryDriverController {
 
         DeliveryDriverDetailResponseDto response = deliveryDriverService.getDriverByDriverId(deliveryDriverId);
         return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{deliveryRouteId}/cancel")
+    public ResponseEntity<Void> cancelDriverStatus(@PathVariable("deliveryRouteId") UUID deliveryRouteId) {
+
+        deliveryDriverService.cancelDriverStatus(deliveryRouteId);
+        return ResponseEntity.ok().build();
     }
 }
 

--- a/user/src/test/java/com/business/user/deliverydriver/application/service/DeliveryDriverServiceTest.java
+++ b/user/src/test/java/com/business/user/deliverydriver/application/service/DeliveryDriverServiceTest.java
@@ -1,0 +1,77 @@
+package com.business.user.deliverydriver.application.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.business.common.application.exception.BusinessLogicException;
+import com.business.user.deliverydriver.domain.entity.DeliveryDriver;
+import com.business.user.deliverydriver.domain.entity.DriverStatus;
+import com.business.user.deliverydriver.domain.repository.DeliveryDriverRepository;
+import java.lang.reflect.Field;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DeliveryDriverServiceTest {
+
+    @Mock
+    private DeliveryDriverRepository deliveryDriverRepository;
+
+    @InjectMocks
+    private DeliveryDriverService deliveryDriverService;
+
+    private UUID deliveryRouteId;
+    private DeliveryDriver deliveryDriver;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        deliveryRouteId = UUID.randomUUID();
+
+        // DeliveryDriver 인스턴스 생성 (빌더 사용)
+        deliveryDriver = DeliveryDriver.deliveryDriverCreateBuilder()
+            .deliveryDriverId(1L)
+            .hubId(UUID.randomUUID())
+            .slackId(UUID.randomUUID())
+            .driverType(null)  // 필요에 따라 타입 지정 (예: DriverType.HUB)
+            .deliverySequence(1L)
+            .driverStatus(DriverStatus.ASSIGNED)
+            .build();
+
+        // DeliveryDriver에 배정된 배송 경로 ID 설정 (Reflection 사용)
+        Field routeField = DeliveryDriver.class.getDeclaredField("deliveryRouteId");
+        routeField.setAccessible(true);
+        routeField.set(deliveryDriver, deliveryRouteId);
+    }
+
+    @Test
+    void cancelDriverStatus_Success() {
+        // given: 해당 배송 경로에 배정된 배송 담당자가 존재하는 경우
+        when(deliveryDriverRepository.findByDeliveryRouteId(deliveryRouteId))
+            .thenReturn(Optional.of(deliveryDriver));
+
+        // when: 배송 담당자 취소 호출
+        deliveryDriverService.cancelDriverStatus(deliveryRouteId);
+
+        // then: 배송 담당자의 상태가 CANCELED로 업데이트되었는지 검증
+        assertEquals(DriverStatus.CANCELED, deliveryDriver.getDriverStatus());
+        // 그리고 변경된 엔티티가 저장되었는지 검증
+        verify(deliveryDriverRepository, times(1)).save(deliveryDriver);
+    }
+
+    @Test
+    void cancelDriverStatus_WhenDriverNotFound_ThrowsException() {
+        // given: 해당 배송 경로에 배정된 배송 담당자가 존재하지 않는 경우
+        when(deliveryDriverRepository.findByDeliveryRouteId(deliveryRouteId))
+            .thenReturn(Optional.empty());
+
+        // when & then: BusinessLogicException이 발생하는지 검증
+        assertThrows(BusinessLogicException.class,
+            () -> deliveryDriverService.cancelDriverStatus(deliveryRouteId));
+    }
+}


### PR DESCRIPTION
## 개요
주문 취소 시 배송 및 배정된 담당자의 취소 API 구현

<br>

## 📝 작업 내용
### 변경 사항

1. DeliveryController.java
   - `PUT /deliveries/{deliveryId}/cancel** 엔드포인트를 추가
   - `DeliveryService.cancelDelivery()`를 호출하여, 배송 취소 시 Delivery 및 연결된 DeliveryRoute의 상태를 CANCELED로 업데이트

2. DeliveryService.java
     - DeliveryRepository를 사용해 논리 삭제 조건에 맞는 Delivery 엔티티를 조회하고,  
       Delivery 도메인 메서드 `updateCancelStatus()`를 통해 전체 배송 및 관련 DeliveryRoute의 상태를 CANCELED로 변경
     - 변경된 Delivery 엔티티를 저장한 후, 할당된 DeliveryRoute ID를 추출하여 외부 UserClient(FeignClient)를 통해 배송 담당자 취소 API를 호출
     - 외부 호출 실패 시 BusinessLogicException(DRIVER_CANCEL_ERROR)를 발생시키도록 처리

3. DeliveryServiceTest.java
     - cancelDelivery_Success() 테스트
       - DeliveryRepository에서 Delivery를 모킹하고, Reflection을 사용해 protected 생성자 및 private 필드를 설정한 Delivery 및 DeliveryRoute 인스턴스를 구성한 후,  
         Delivery와 DeliveryRoute의 상태가 CANCELED로 업데이트되고, UserClient.cancelDriverStatus()가 올바른 routeId로 1회 호출되는지 검증
     - cancelDelivery_WhenNoAssignedRoute_ThrowsException() 테스트
       - 할당된 DeliveryRoute가 없는 경우 BusinessLogicException이 발생하는지 확인

4. UserClient.java
   -  PUT /api/v1/delivery-drivers/{deliveryRouteId}/cancel 엔드포인트를 통해 배송 담당자 취소 API를 호출

5. DeliveryDriverController.java
     - PUT /api/v1/delivery-drivers/{deliveryRouteId}/cancel** 엔드포인트를 추가
     - 이 엔드포인트는 DeliveryDriverService의 cancelDriverStatus() 메서드를 호출하여, 배정된 배송 경로 ID를 기반으로 배송 담당자의 상태를 CANCELED로 업데이트

6. DeliveryDriverService.java
     - DeliveryDriverRepository의 `findByDeliveryRouteIdAndDeletedAtIsNull(UUID deliveryRouteId)` 메서드를 사용해 해당 배송 경로에 배정된 배송 담당자를 조회하고,  
       도메인 메서드 `updateCancelStatus()`를 호출하여 배송 담당자의 상태를 CANCELED로 변경
     - 조회 실패 시 BusinessLogicException(배송 담당자 관련 에러 코드)을 발생

7. DeliveryDriverServiceTest.java
     - cancelDriverStatus_Success() 테스트
       배정된 배송 경로 ID를 통해 배송 담당자를 성공적으로 조회, 상태가 CANCELED로 업데이트되고, repository.save()가 1회 호출되는지 검증
     - cancelDriverStatus_WhenDriverNotFound_ThrowsException() 테스트 
       배송 경로 ID로 조회 시 배송 담당자가 없을 경우, BusinessLogicException이 발생하는지 확인

8. Domain
   - Delivery.java
     - `updateCancelStatus()` 도메인 메서드를 추가하여, Delivery 상태를 CANCELED로 설정하고, 연결된 DeliveryRoute들에 대해 updateCancelStatus()를 호출하도록 구현
   - DeliveryRoute.java
     - `updateCancelStatus()` 도메인 메서드를 추가하여, 해당 DeliveryRoute의 상태를 CANCELED로 변경하도록 구현
   - DeliveryDriver.java
     - `updateCancelStatus()` 도메인 메서드를 추가하여, 해당 배송 담당자의(DeliveryDriver) 상태를 CANCELED로 변경하도록 구현

9. DeliveryDriverRepository
   - 논리 삭제 조건에 맞는 배송 담당자를 배정된 배송 경로 ID 기준으로 조회

### 변경 이유

### 추가 설명

<br>

### 💬리뷰 요구사항
- 배송 취소 플로우 및 배송 담당자 취소 호출이 정상적으로 동작함을 확인하였습니다.
- 추후 주석 제거하겠습니다.

<br>

### #️⃣ 연관된 이슈
closed #236 

<br>

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [X] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

<br>

## ✅ Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
