### PR TITLE
fix: Delivery 저장 시 즉시 flush를 위한 saveAndFlush 메서드 추가

### DIFF
--- a/delivery/src/main/java/com/business/delivery/application/service/DeliveryService.java
+++ b/delivery/src/main/java/com/business/delivery/application/service/DeliveryService.java
@@ -91,7 +91,7 @@ public class DeliveryService {
 
         delivery.addDeliveryRoute(allRoutes);
 
-        Delivery savedDelivery = deliveryRepository.save(delivery);
+        Delivery savedDelivery = deliveryRepository.saveAndFlush(delivery);
 
         assignDeliveryDriver(savedDelivery.getDeliveryId());
 

--- a/delivery/src/main/java/com/business/delivery/domain/repository/DeliveryRepository.java
+++ b/delivery/src/main/java/com/business/delivery/domain/repository/DeliveryRepository.java
@@ -10,6 +10,8 @@ public interface DeliveryRepository {
 
   Delivery save(Delivery delivery);
 
+  Delivery saveAndFlush(Delivery delivery);
+
   Page<Delivery> findDeliveries(SearchRequestDto request, Pageable pageable);
 
   Delivery findByDeliveryId(UUID deliveryId);

--- a/delivery/src/main/java/com/business/delivery/infrastructure/repository/DeliveryRepositoryImpl.java
+++ b/delivery/src/main/java/com/business/delivery/infrastructure/repository/DeliveryRepositoryImpl.java
@@ -32,6 +32,11 @@ public class DeliveryRepositoryImpl implements DeliveryRepository {
   }
 
   @Override
+  public Delivery saveAndFlush(Delivery delivery) {
+    return deliveryJpaRepository.saveAndFlush(delivery);
+  }
+
+  @Override
   public Page<Delivery> findDeliveries(SearchRequestDto request, Pageable pageable) {
 
     JPAQueryFactory queryFactory = new JPAQueryFactory(entityManager);


### PR DESCRIPTION
## 개요
Delivery 엔티티 저장 시 즉시 flush를 수행하여, DB에서 생성되는 deliveryId를 바로 사용할 수 있도록 보장하기 위해 구현했습니다.

<br>

## 📝 작업 내용
### 변경 사항
- DeliveryRepository 인터페이스에 saveAndFlush 메서드 시그니처 추가
- DeliveryRepositoryImpl에서 deliveryJpaRepository.saveAndFlush()를 호출하여 구현
- 이를 통해 Delivery 엔티티 저장 후 즉시 deliveryId가 생성되어 사용 가능하도록 보장

### 변경 이유

### 추가 설명

<br>

### 💬리뷰 요구사항

<br>

### #️⃣ 연관된 이슈
closed #247 

<br>

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

<br>

## ✅ Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
