### PR TITLE
bugfix: 권한 체크를 위한 사용자 정보 헤더(userId, role) 추가

### DIFF
--- a/delivery/src/main/java/com/business/delivery/application/service/DeliveryService.java
+++ b/delivery/src/main/java/com/business/delivery/application/service/DeliveryService.java
@@ -47,7 +47,7 @@ public class DeliveryService {
     private final UserClient userClient;
     private final OrderClient orderClient;
 
-    public DeliveryResponseDto createDelivery(CreateDeliveryRequestDto request, Long userId) {
+    public DeliveryResponseDto createDelivery(CreateDeliveryRequestDto request, Long userId, String role) {
 
         if (userId == null) {
             throw new BusinessLogicException(DeliveryErrorCode.INVALID_USER_ID);
@@ -61,7 +61,7 @@ public class DeliveryService {
         }
 
         List<HubRoutesResponseDto> hubMovements = Optional
-            .ofNullable(hubClient.getRoutesByStartAndEndHub(request.getStartHubId(), request.getEndHubId()))
+            .ofNullable(hubClient.getRoutesByStartAndEndHub(request.getStartHubId(), request.getEndHubId(), userId, role))
             .filter(list -> !list.isEmpty())
             .orElseThrow(() -> new BusinessLogicException(DeliveryErrorCode.HUB_MOVEMENT_NOT_AVAILABLE));
 
@@ -70,7 +70,7 @@ public class DeliveryService {
                 .mapToObj(i -> HubMapper.toEntityFromHubMovement(hubMovements.get(i), (long) i + 1))
                 .toList();
 
-        HubIdResponseDto hubInfo = hubClient.getLatitudeAndLongitude(request.getEndHubId());
+        HubIdResponseDto hubInfo = hubClient.getLatitudeAndLongitude(request.getEndHubId(), userId, role);
         if (hubInfo == null || hubInfo.getLatitude() == null || hubInfo.getLongitude() == null) {
             throw new BusinessLogicException(DeliveryErrorCode.HUB_COORDINATE_NOT_AVAILABLE);
         }
@@ -122,18 +122,19 @@ public class DeliveryService {
 
         Delivery savedDelivery = deliveryRepository.saveAndFlush(delivery);
 
-        assignDeliveryDriver(savedDelivery.getDeliveryId());
+        assignDeliveryDriver(savedDelivery.getDeliveryId(), userId, role);
 
         return DeliveryResponseMapper.deliveryToDeliveryResponseDto(savedDelivery);
     }
 
-    private void assignDeliveryDriver(UUID deliveryId) {
+    private void assignDeliveryDriver(UUID deliveryId, Long userId, String role) {
 
-        userClient.assignDeliveryDriver(deliveryId);
+        userClient.assignDeliveryDriver(deliveryId, userId, role);
+
     }
 
     @Transactional(readOnly = true)
-    public Page<DeliveryPageResponseDto> getDeliveries(SearchRequestDto request, Long userId) {
+    public Page<DeliveryPageResponseDto> getDeliveries(SearchRequestDto request, Long userId, String role) {
 
         if (userId == null) {
             throw new BusinessLogicException(DeliveryErrorCode.INVALID_USER_ID);
@@ -148,7 +149,7 @@ public class DeliveryService {
         return responsePage;
     }
 
-    public DeliveryDetailResponseDto getDeliveryByDeliveryId(UUID deliveryId, Long userId) {
+    public DeliveryDetailResponseDto getDeliveryByDeliveryId(UUID deliveryId, Long userId, String role) {
 
         if (userId == null) {
             throw new BusinessLogicException(DeliveryErrorCode.INVALID_USER_ID);
@@ -160,13 +161,13 @@ public class DeliveryService {
             throw new BusinessLogicException(DeliveryErrorCode.DELIVERY_NOT_FOUND);
         }
 
-        Map<String, Object> orderResponse = orderClient.getOrder(delivery.getOrderId());
+        Map<String, Object> orderResponse = orderClient.getOrder(delivery.getOrderId(), userId, role);
 
         return DeliveryResponseMapper.deliveryAndOrderToDetailResponse(delivery, orderResponse);
     }
 
     @Transactional
-    public DeliveryStatusUpdateResponseDto updateDeliveryStatus(UUID deliveryId, StatusUpdateRequestDto request, Long userId) {
+    public DeliveryStatusUpdateResponseDto updateDeliveryStatus(UUID deliveryId, StatusUpdateRequestDto request, Long userId, String role) {
 
         if (userId == null) {
             throw new BusinessLogicException(DeliveryErrorCode.INVALID_USER_ID);
@@ -197,16 +198,16 @@ public class DeliveryService {
             updatedDelivery.updateStatus(DeliveryStatus.DELIVERED);
             updatedDelivery = deliveryRepository.save(updatedDelivery);
 
-            orderClient.completeOrder(updatedDelivery.getOrderId());
+            orderClient.completeOrder(updatedDelivery.getOrderId(), userId, role);
         }
 
-        userClient.updateDriverStatus(deliveryRoute.getDeliveryRouteId());
+        userClient.updateDriverStatus(deliveryRoute.getDeliveryRouteId(), userId, role);
 
         return DeliveryResponseMapper.toStatusUpdateResponse(updatedDelivery, deliveryRoute);
     }
 
     @Transactional
-    public void cancelDelivery(UUID deliveryId, Long userId) {
+    public void cancelDelivery(UUID deliveryId, Long userId, String role) {
 
         if (userId == null) {
             throw new BusinessLogicException(DeliveryErrorCode.INVALID_USER_ID);
@@ -229,14 +230,14 @@ public class DeliveryService {
             .orElseThrow(() -> new BusinessLogicException(DeliveryErrorCode.DELIVERY_ROUTE_NOT_FOUND));
 
         try {
-            userClient.cancelDriverStatus(deliveryRouteId);
+            userClient.cancelDriverStatus(deliveryRouteId, userId, role);
         } catch (Exception e) {
             throw new BusinessLogicException(DeliveryErrorCode.DRIVER_CANCEL_ERROR);
         }
     }
 
     @Transactional
-    public void deleteByDeliveryId(UUID deliveryId, Long deletedBy, Long userId) {
+    public void deleteByDeliveryId(UUID deliveryId, Long deletedBy, Long userId, String role) {
 
         if (userId == null) {
             throw new BusinessLogicException(DeliveryErrorCode.INVALID_USER_ID);

--- a/delivery/src/main/java/com/business/delivery/infrastructure/client/HubClient.java
+++ b/delivery/src/main/java/com/business/delivery/infrastructure/client/HubClient.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(name = "hub-service", url = "${hub.service.url}")
@@ -15,12 +16,15 @@ public interface HubClient {
   @GetMapping("/api/v1/hub-movements/routes")
   List<HubRoutesResponseDto> getRoutesByStartAndEndHub(
       @RequestParam("departureHubId") UUID startHubId,
-      @RequestParam("arrivalHubId") UUID endHubId
+      @RequestParam("arrivalHubId") UUID endHubId,
+      @RequestHeader("X-client-userId") Long userId,
+      @RequestHeader("X-client-role") String role
   );
 
   @GetMapping("/api/v1/hubs/{hub_id}")
   HubIdResponseDto getLatitudeAndLongitude(
-      @PathVariable("hub_id") UUID endHubId
+      @PathVariable("hub_id") UUID endHubId,
+      @RequestHeader("X-client-userId") Long userId,
+      @RequestHeader("X-client-role") String role
   );
 }
-

--- a/delivery/src/main/java/com/business/delivery/infrastructure/client/OrderClient.java
+++ b/delivery/src/main/java/com/business/delivery/infrastructure/client/OrderClient.java
@@ -4,17 +4,24 @@ import java.util.Map;
 import java.util.UUID;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.Mapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 @FeignClient(name = "order-service", url = "${order.service.url}")
 public interface OrderClient {
 
     @GetMapping("/api/v1/orders/{orderId}")
-    Map<String, Object> getOrder(@PathVariable("orderId") UUID orderId);
+    Map<String, Object> getOrder(
+        @PathVariable("orderId") UUID orderId,
+        @RequestHeader("X-client-userId") Long userId,
+        @RequestHeader("X-client-role") String role
+    );
 
     @PatchMapping("/api/v1/orders/{orderId}/completed")
-    void completeOrder(@PathVariable("orderId") UUID orderId);
+    void completeOrder(
+        @PathVariable("orderId") UUID orderId,
+        @RequestHeader("X-client-userId") Long userId,
+        @RequestHeader("X-client-role") String role
+    );
 }

--- a/delivery/src/main/java/com/business/delivery/infrastructure/client/UserClient.java
+++ b/delivery/src/main/java/com/business/delivery/infrastructure/client/UserClient.java
@@ -2,18 +2,33 @@ package com.business.delivery.infrastructure.client;
 
 import java.util.UUID;
 import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(name = "user-service", url = "${user.service.url}")
 public interface UserClient {
 
   @PostMapping("/api/v1/delivery-drivers/assign")
-  Long assignDeliveryDriver(@RequestParam("delivery_id") UUID deliveryId);
+  Long assignDeliveryDriver(
+      @RequestParam("delivery_id") UUID deliveryId,
+      @RequestHeader("X-client-userId") Long userId,
+      @RequestHeader("X-client-role") String role
+  );
 
-  @PutMapping("/drivers/{deliveryRouteId}/status")
-  void updateDriverStatus(@PathVariable("deliveryRouteId") UUID deliveryRouteId);
+  @PatchMapping("/drivers/{deliveryRouteId}/status")
+  void updateDriverStatus(
+      @PathVariable("deliveryRouteId") UUID deliveryRouteId,
+      @RequestHeader("X-client-userId") Long userId,
+      @RequestHeader("X-client-role") String role
+  );
 
-  @PutMapping("/api/v1/delivery-drivers/{deliveryRouteId}/cancel")
-  void cancelDriverStatus(@PathVariable("deliveryRouteId") UUID deliveryRouteId);
-
+  @PatchMapping("/api/v1/delivery-drivers/{deliveryRouteId}/cancel")
+  void cancelDriverStatus(
+      @PathVariable("deliveryRouteId") UUID deliveryRouteId,
+      @RequestHeader("X-client-userId") Long userId,
+      @RequestHeader("X-client-role") String role
+  );
 }

--- a/delivery/src/main/java/com/business/delivery/presentation/controller/DeliveryController.java
+++ b/delivery/src/main/java/com/business/delivery/presentation/controller/DeliveryController.java
@@ -39,20 +39,21 @@ public class DeliveryController {
     @PostMapping
     public ResponseEntity<DeliveryResponseDto> createDelivery(
         @Valid @RequestBody CreateDeliveryRequestDto request,
-        @RequestHeader("X-client-userId") Long userId
+        @RequestHeader("X-client-userId") Long userId,
+        @RequestHeader("X-client-role") String role
     ) {
-
-        DeliveryResponseDto response = deliveryService.createDelivery(request, userId);
+        DeliveryResponseDto response = deliveryService.createDelivery(request, userId, role);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @RoleCheck(roles = {"ROLE_MASTER","ROLE_HUB", "ROLE_DELIVERY", "ROLE_COMPANY"})
+    @RoleCheck(roles = {"ROLE_MASTER", "ROLE_HUB", "ROLE_DELIVERY", "ROLE_COMPANY"})
     @GetMapping
     public ResponseEntity<DeliveryPageListResponseDto<DeliveryPageResponseDto>> getDeliveries(
         SearchRequestDto request,
-        @RequestHeader("X-client-userId") Long userId) {
-
-        Page<DeliveryPageResponseDto> deliveryPage = deliveryService.getDeliveries(request, userId);
+        @RequestHeader("X-client-userId") Long userId,
+        @RequestHeader("X-client-role") String role
+    ) {
+        Page<DeliveryPageResponseDto> deliveryPage = deliveryService.getDeliveries(request, userId, role);
         return ResponseEntity.ok(DeliveryResponseMapper.toPageListResponse(deliveryPage));
     }
 
@@ -60,40 +61,45 @@ public class DeliveryController {
     @GetMapping("/{deliveryId}")
     public ResponseEntity<DeliveryDetailResponseDto> getDeliveryDetail(
         @PathVariable("deliveryId") UUID deliveryId,
-        @RequestHeader("X-client-userId") Long userId) {
-
-        DeliveryDetailResponseDto response = deliveryService.getDeliveryByDeliveryId(deliveryId, userId);
+        @RequestHeader("X-client-userId") Long userId,
+        @RequestHeader("X-client-role") String role
+    ) {
+        DeliveryDetailResponseDto response = deliveryService.getDeliveryByDeliveryId(deliveryId, userId, role);
         return ResponseEntity.ok(response);
     }
 
-    @RoleCheck(roles = {"ROLE_MASTER","ROLE_HUB", "ROLE_DELIVERY"})
+    @RoleCheck(roles = {"ROLE_MASTER", "ROLE_HUB", "ROLE_DELIVERY"})
     @PatchMapping("/{deliveryId}/status")
     public ResponseEntity<DeliveryStatusUpdateResponseDto> updateDeliveryStatus(
         @PathVariable("deliveryId") UUID deliveryId,
         @Valid @RequestBody StatusUpdateRequestDto request,
-        @RequestHeader("X-client-userId") Long userId) {
-
-        DeliveryStatusUpdateResponseDto response =
-            deliveryService.updateDeliveryStatus(deliveryId, request, userId);
+        @RequestHeader("X-client-userId") Long userId,
+        @RequestHeader("X-client-role") String role
+    ) {
+        DeliveryStatusUpdateResponseDto response = deliveryService.updateDeliveryStatus(deliveryId, request, userId, role);
         return ResponseEntity.ok(response);
     }
 
-    @RoleCheck(roles = {"ROLE_MASTER","ROLE_HUB", "ROLE_DELIVERY"})
+    @RoleCheck(roles = {"ROLE_MASTER", "ROLE_HUB", "ROLE_DELIVERY"})
     @PatchMapping("/{deliveryId}/cancel")
-    public ResponseEntity<Void> cancelDelivery(@PathVariable("deliveryId") UUID deliveryId,
-        @RequestHeader("X-client-userId") Long userId) {
-
-        deliveryService.cancelDelivery(deliveryId, userId);
+    public ResponseEntity<Void> cancelDelivery(
+        @PathVariable("deliveryId") UUID deliveryId,
+        @RequestHeader("X-client-userId") Long userId,
+        @RequestHeader("X-client-role") String role
+    ) {
+        deliveryService.cancelDelivery(deliveryId, userId, role);
         return ResponseEntity.ok().build();
     }
 
-    @RoleCheck(roles = {"ROLE_MASTER","ROLE_HUB"})
+    @RoleCheck(roles = {"ROLE_MASTER", "ROLE_HUB"})
     @DeleteMapping("/{deliveryId}")
-    public ResponseEntity<Void> deleteByDeliveryId(@PathVariable("deliveryId") UUID deliveryId,
+    public ResponseEntity<Void> deleteByDeliveryId(
+        @PathVariable("deliveryId") UUID deliveryId,
         @RequestParam Long deletedBy,
-        @RequestHeader("X-client-userId") Long userId) {
-
-        deliveryService.deleteByDeliveryId(deliveryId, deletedBy, userId);
+        @RequestHeader("X-client-userId") Long userId,
+        @RequestHeader("X-client-role") String role
+    ) {
+        deliveryService.deleteByDeliveryId(deliveryId, deletedBy, userId, role);
         return ResponseEntity.noContent().build();
     }
 }

--- a/delivery/src/test/java/com/business/delivery/application/service/DeliveryServiceCancelTest.java
+++ b/delivery/src/test/java/com/business/delivery/application/service/DeliveryServiceCancelTest.java
@@ -42,12 +42,15 @@ class DeliveryServiceCancelTest {
   private Delivery delivery;
   private DeliveryRoute deliveryRoute;
 
+  private final Long userId = 1L;
+  private final String role = "ROLE_HUB";
+
   @BeforeEach
   void setUp() throws Exception {
     deliveryId = UUID.randomUUID();
     routeId = UUID.randomUUID();
 
-    lenient().doNothing().when(mockUserClient).cancelDriverStatus(any(UUID.class));
+    lenient().doNothing().when(mockUserClient).cancelDriverStatus(any(UUID.class), any(Long.class), any(String.class));
 
     deliveryRoute = DeliveryRoute.deliveryRouteCreateBuilder()
         .delivery(null)
@@ -67,35 +70,30 @@ class DeliveryServiceCancelTest {
     delivery = createDeliveryInstance();
 
     setDeliveryStatus(delivery, DeliveryStatus.WAITING_AT_HUB);
-
     setDeliveryRoutes(delivery, List.of(deliveryRoute));
-
     associateRouteWithDelivery(deliveryRoute, delivery);
   }
 
   @Test
   void cancelDelivery_Success() throws Exception {
-    Long testUserId = 1L;
-
     when(deliveryRepository.findByDeliveryId(deliveryId)).thenReturn(delivery);
 
-    deliveryService.cancelDelivery(deliveryId, testUserId);
+    deliveryService.cancelDelivery(deliveryId, userId, role);
 
     assertEquals(DeliveryStatus.CANCELED, getDeliveryStatus(delivery));
     assertEquals(DeliveryRouteStatus.CANCELED, deliveryRoute.getDeliveryRouteStatus());
 
-    verify(mockUserClient, times(1)).cancelDriverStatus(routeId);
+    verify(mockUserClient, times(1)).cancelDriverStatus(routeId, userId, role);
   }
+
 
   @Test
   void cancelDelivery_WhenNoAssignedRoute_ThrowsException() throws Exception {
-    Long testUserId = 1L;
-
     setDeliveryRoutes(delivery, Collections.emptyList());
     when(deliveryRepository.findByDeliveryId(deliveryId)).thenReturn(delivery);
 
-    BusinessLogicException ex = assertThrows(BusinessLogicException.class,
-        () -> deliveryService.cancelDelivery(deliveryId, testUserId)
+    assertThrows(BusinessLogicException.class, () ->
+        deliveryService.cancelDelivery(deliveryId, userId, role)
     );
   }
 

--- a/delivery/src/test/java/com/business/delivery/application/service/DeliveryServiceStatusTest.java
+++ b/delivery/src/test/java/com/business/delivery/application/service/DeliveryServiceStatusTest.java
@@ -42,13 +42,13 @@ class DeliveryServiceStatusTest {
     private Delivery delivery;
     private DeliveryRoute activeRoute;
     private UUID deliveryId;
-    private UUID routeId;
     private final Long userId = 1L;
+    private final String role = "ROLE_HUB";
 
     @BeforeEach
     void setUp() throws Exception {
         deliveryId = UUID.randomUUID();
-        routeId = UUID.randomUUID();
+        UUID routeId = UUID.randomUUID();
 
         delivery = Delivery.deliveryCreateBuilder()
             .orderId(UUID.randomUUID())
@@ -83,12 +83,14 @@ class DeliveryServiceStatusTest {
         when(deliveryRepository.findByDeliveryId(deliveryId)).thenReturn(delivery);
         when(deliveryRepository.save(any(Delivery.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        DeliveryStatusUpdateResponseDto responseDto = deliveryService.updateDeliveryStatus(deliveryId, request, userId);
+        DeliveryStatusUpdateResponseDto responseDto =
+            deliveryService.updateDeliveryStatus(deliveryId, request, userId, role);
+
 
         assertEquals(DeliveryStatus.OUT_FOR_DELIVERY, responseDto.getDeliveryStatus());
         assertEquals(DeliveryRouteStatus.IN_TRANSIT_TO_HUB, responseDto.getDeliveryRouteStatus());
 
-        verify(mockUserClient, times(1)).updateDriverStatus(activeRoute.getDeliveryRouteId());
+        verify(mockUserClient, times(1)).updateDriverStatus(activeRoute.getDeliveryRouteId(), userId, role);
     }
 
     @Test
@@ -102,7 +104,8 @@ class DeliveryServiceStatusTest {
             .build();
 
         assertThrows(BusinessLogicException.class, () -> {
-            deliveryService.updateDeliveryStatus(deliveryId, request, userId);
+            deliveryService.updateDeliveryStatus(deliveryId, request, userId, role);
+
         });
     }
 
@@ -118,7 +121,8 @@ class DeliveryServiceStatusTest {
             .build();
 
         assertThrows(BusinessLogicException.class, () -> {
-            deliveryService.updateDeliveryStatus(deliveryId, request, userId);
+            deliveryService.updateDeliveryStatus(deliveryId, request, userId, role);
+
         });
     }
 
@@ -166,12 +170,13 @@ class DeliveryServiceStatusTest {
         when(deliveryRepository.findByDeliveryId(deliveryId)).thenReturn(delivery);
         when(deliveryRepository.save(any(Delivery.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        DeliveryStatusUpdateResponseDto responseDto = deliveryService.updateDeliveryStatus(deliveryId, request, userId);
+        DeliveryStatusUpdateResponseDto responseDto =
+            deliveryService.updateDeliveryStatus(deliveryId, request, userId, role);
 
         assertEquals(DeliveryStatus.DELIVERED, responseDto.getDeliveryStatus());
         assertEquals(DeliveryRouteStatus.IN_TRANSIT_TO_HUB, responseDto.getDeliveryRouteStatus());
 
-        verify(mockUserClient, times(1)).updateDriverStatus(route1.getDeliveryRouteId());
+        verify(mockUserClient, times(1)).updateDriverStatus(route1.getDeliveryRouteId(), userId, role);
     }
 
     @Test
@@ -207,15 +212,17 @@ class DeliveryServiceStatusTest {
         when(deliveryRepository.findByDeliveryId(deliveryId)).thenReturn(delivery);
         when(deliveryRepository.save(any(Delivery.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        DeliveryStatusUpdateResponseDto responseDto = deliveryService.updateDeliveryStatus(deliveryId, request, userId);
+        DeliveryStatusUpdateResponseDto responseDto =
+            deliveryService.updateDeliveryStatus(deliveryId, request, userId, role);
 
-        verify(mockUserClient, times(1)).updateDriverStatus(activeRoute.getDeliveryRouteId());
+
+        verify(mockUserClient, times(1)).updateDriverStatus(activeRoute.getDeliveryRouteId(), userId, role);
     }
 
     @Test
     void testUpdateDeliveryStatus_LastRouteNotDelivered_NoCompleteOrderCall() {
 
-        StatusUpdateRequestDto requestDto = StatusUpdateRequestDto.builder()
+        StatusUpdateRequestDto request = StatusUpdateRequestDto.builder()
             .deliveryStatus(DeliveryStatus.OUT_FOR_DELIVERY)
             .deliveryRouteStatus(DeliveryRouteStatus.ARRIVED_AT_HUB)
             .build();
@@ -224,9 +231,11 @@ class DeliveryServiceStatusTest {
         when(deliveryRepository.save(any(Delivery.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         DeliveryStatusUpdateResponseDto responseDto =
-            deliveryService.updateDeliveryStatus(deliveryId, requestDto, userId);
+            deliveryService.updateDeliveryStatus(deliveryId, request, userId, role);
+
 
         assertEquals(DeliveryStatus.OUT_FOR_DELIVERY, responseDto.getDeliveryStatus());
-        verify(mockOrderClient, never()).completeOrder(any(UUID.class));
+        verify(mockOrderClient, never())
+            .completeOrder(any(UUID.class), eq(userId), eq(role));
     }
 }

--- a/user/src/main/java/com/business/user/deliverydriver/application/service/DeliveryDriverService.java
+++ b/user/src/main/java/com/business/user/deliverydriver/application/service/DeliveryDriverService.java
@@ -36,10 +36,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class DeliveryDriverService {
 
     private final DeliveryDriverRepository deliveryDriverRepository;
-    private final HubClient hubClient;
     private final DeliveryClient deliveryClient;
 
-    public DeliveryDriverResponseDto createDeliveryDriver(CreateDeliveryDriverRequestDto request, Long userId) {
+    public DeliveryDriverResponseDto createDeliveryDriver(CreateDeliveryDriverRequestDto request, Long userId, String role) {
 
         if (userId == null) {
             throw new BusinessLogicException(DeliveryDriverErrorCode.INVALID_USER_ID);
@@ -54,8 +53,9 @@ public class DeliveryDriverService {
         }
 
         if (request.getDriverType() == DriverType.COMPANY) {
-            if (request.getHubId() == null || !hubClient.existsByHubId(request.getHubId().toString())) {
-                throw new BusinessLogicException(DeliveryDriverErrorCode.EXTERNAL_HUB_NOT_FOUND);
+            long companyDriverCount = deliveryDriverRepository.countByHubIdAndDriverType(request.getHubId(), DriverType.COMPANY);
+            if (companyDriverCount >= 10) {
+                throw new BusinessLogicException(DeliveryDriverErrorCode.MAX_COMPANY_DRIVERS_PER_HUB_EXCEEDED);
             }
         }
 
@@ -78,7 +78,6 @@ public class DeliveryDriverService {
             case COMPANY -> deliveryDriverRepository.findLastDeliverySequenceForCompanyDrivers(request.getHubId()).orElse(0L) + 1;
         };
 
-
         DeliveryDriver deliveryDriver =
             DeliveryDriverRequestMapper.createRequestToEntity(request, newSequence);
 
@@ -87,14 +86,13 @@ public class DeliveryDriverService {
         return DeliveryDriverResponseMapper.driverToDriverResponseDto(deliveryDriver);
     }
 
-
-    public List<AssignDeliveryDriverResponseDto> assignDriversForDelivery(UUID deliveryId, Long userId) {
+    public List<AssignDeliveryDriverResponseDto> assignDriversForDelivery(UUID deliveryId, Long userId, String role) {
 
         if (userId == null) {
             throw new BusinessLogicException(DeliveryDriverErrorCode.INVALID_USER_ID);
         }
 
-        List<DeliveryClientResponseDto> routes = deliveryClient.getRoutesByDeliveryId(deliveryId);
+        List<DeliveryClientResponseDto> routes = deliveryClient.getRoutesByDeliveryId(deliveryId, userId, role);
 
         List<AssignDeliveryDriverResponseDto> assignedDrivers = new ArrayList<>();
 
@@ -161,11 +159,13 @@ public class DeliveryDriverService {
     }
 
     @Transactional(readOnly = true)
-    public Page<DeliveryDriverResponseDto> getDrivers(DeliveryDriverSearchRequestDto request, Long userId) {
+    public Page<DeliveryDriverResponseDto> getDrivers(DeliveryDriverSearchRequestDto request, Long userId, String role) {
 
         if (userId == null) {
             throw new BusinessLogicException(DeliveryDriverErrorCode.INVALID_USER_ID);
         }
+
+
 
         Pageable pageable = DeliveryDriverRequestMapper.SearchRequestDtoToPageable(request);
 
@@ -174,7 +174,7 @@ public class DeliveryDriverService {
     }
 
     @Transactional(readOnly = true)
-    public DeliveryDriverDetailResponseDto getDriverByDriverId(Long deliveryDriverId, Long userId) {
+    public DeliveryDriverDetailResponseDto getDriverByDriverId(Long deliveryDriverId, Long userId, String role) {
 
         if (userId == null) {
             throw new BusinessLogicException(DeliveryDriverErrorCode.INVALID_USER_ID);
@@ -188,7 +188,7 @@ public class DeliveryDriverService {
             throw new BusinessLogicException(DeliveryDriverErrorCode.DELIVERY_ROUTE_NOT_ASSIGNED);
         }
 
-        List<DeliveryClientResponseDto> deliveryRoutes = safeGetRoutesByDeliveryId(deliveryRouteId);
+        List<DeliveryClientResponseDto> deliveryRoutes = safeGetRoutesByDeliveryId(deliveryRouteId, userId, role);
         if (deliveryRoutes.isEmpty()) {
             throw new BusinessLogicException(DeliveryDriverErrorCode.EXTERNAL_DELIVERY_ROUTE_NOT_FOUND);
         }
@@ -201,10 +201,9 @@ public class DeliveryDriverService {
         return DeliveryDriverResponseMapper.driverToDriverDetailDto(deliveryDriver, assignedRoute);
     }
 
-    private List<DeliveryClientResponseDto> safeGetRoutesByDeliveryId(UUID deliveryRouteId) {
-
+    private List<DeliveryClientResponseDto> safeGetRoutesByDeliveryId(UUID deliveryRouteId, Long userId, String role) {
         try {
-            List<DeliveryClientResponseDto> routes = deliveryClient.getRoutesByDeliveryId(deliveryRouteId);
+            List<DeliveryClientResponseDto> routes = deliveryClient.getRoutesByDeliveryId(deliveryRouteId, userId, role);
             return routes == null ? Collections.emptyList() : routes;
         } catch (Exception e) {
             throw new BusinessLogicException(DeliveryDriverErrorCode.EXTERNAL_DELIVERY_ROUTE_NOT_FOUND);
@@ -212,7 +211,7 @@ public class DeliveryDriverService {
     }
 
     @Transactional
-    public DriverStatusUpdateResponseDto updateDriverStatus(UUID deliveryRouteId, StatusUpdateRequestDto request, Long userId) {
+    public DriverStatusUpdateResponseDto updateDriverStatus(UUID deliveryRouteId, StatusUpdateRequestDto request, Long userId, String role) {
 
         if (userId == null) {
             throw new BusinessLogicException(DeliveryDriverErrorCode.INVALID_USER_ID);
@@ -230,7 +229,7 @@ public class DeliveryDriverService {
     }
 
     @Transactional
-    public void cancelDriverStatus(UUID deliveryRouteId, Long userId) {
+    public void cancelDriverStatus(UUID deliveryRouteId, Long userId, String role) {
 
         if (userId == null) {
             throw new BusinessLogicException(DeliveryDriverErrorCode.INVALID_USER_ID);

--- a/user/src/main/java/com/business/user/deliverydriver/infrastructure/client/DeliveryClient.java
+++ b/user/src/main/java/com/business/user/deliverydriver/infrastructure/client/DeliveryClient.java
@@ -6,10 +6,15 @@ import java.util.UUID;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 @FeignClient(name = "delivery-service", url = "${delivery.service.url}")
 public interface DeliveryClient {
 
   @GetMapping("/api/v1/deliveries/{deliveryId}")
-  List<DeliveryClientResponseDto> getRoutesByDeliveryId(@PathVariable("deliveryId") UUID deliveryId);
+  List<DeliveryClientResponseDto> getRoutesByDeliveryId(
+      @PathVariable("deliveryId") UUID deliveryId,
+      @RequestHeader("X-client-userId") Long userId,
+      @RequestHeader("X-client-role") String role
+  );
 }

--- a/user/src/main/java/com/business/user/deliverydriver/infrastructure/client/HubClient.java
+++ b/user/src/main/java/com/business/user/deliverydriver/infrastructure/client/HubClient.java
@@ -2,11 +2,16 @@ package com.business.user.deliverydriver.infrastructure.client;
 
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(name = "hub-service", url = "${hub.service.url}")
 public interface HubClient {
 
   @GetMapping("/api/v1/hubs")
-  boolean existsByHubId(@RequestParam("hubId") String hubId);
+  boolean existsByHubId(
+      @RequestParam("hubId") String hubId,
+      @RequestHeader("X-client-userId") Long userId,
+      @RequestHeader("X-client-role") String role
+  );
 }

--- a/user/src/main/java/com/business/user/deliverydriver/presentation/controller/DeliveryDriverController.java
+++ b/user/src/main/java/com/business/user/deliverydriver/presentation/controller/DeliveryDriverController.java
@@ -38,9 +38,10 @@ public class DeliveryDriverController {
     @PostMapping
     public ResponseEntity<DeliveryDriverResponseDto> createDeliveryDriver(
         @RequestBody CreateDeliveryDriverRequestDto request,
-        @RequestHeader("X-client-userId") Long userId) {
+        @RequestHeader("X-client-userId") Long userId,
+        @RequestHeader("X-client-role") String role) {
 
-        DeliveryDriverResponseDto responseDto = deliveryDriverService.createDeliveryDriver(request, userId);
+        DeliveryDriverResponseDto responseDto = deliveryDriverService.createDeliveryDriver(request, userId, role);
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
     }
 
@@ -48,10 +49,11 @@ public class DeliveryDriverController {
     @PostMapping("/assign")
     public ResponseEntity<List<AssignDeliveryDriverResponseDto>> assignDriversForDelivery(
         @RequestBody AssignDeliveryDriverRequestDto request,
-        @RequestHeader("X-client-userId") Long userId) {
+        @RequestHeader("X-client-userId") Long userId,
+        @RequestHeader("X-client-role") String role) {
 
         List<AssignDeliveryDriverResponseDto> assignedDrivers =
-            deliveryDriverService.assignDriversForDelivery(request.getDeliveryId(), userId);
+            deliveryDriverService.assignDriversForDelivery(request.getDeliveryId(), userId, role);
         return ResponseEntity.ok(assignedDrivers);
     }
 
@@ -59,9 +61,10 @@ public class DeliveryDriverController {
     @GetMapping
     public ResponseEntity<DeliveryDriverListResponseDto<DeliveryDriverResponseDto>> getDrivers(
         DeliveryDriverSearchRequestDto request,
-        @RequestHeader("X-client-userId") Long userId) {
+        @RequestHeader("X-client-userId") Long userId,
+        @RequestHeader("X-client-role") String role) {
 
-        Page<DeliveryDriverResponseDto> driverPage = deliveryDriverService.getDrivers(request, userId);
+        Page<DeliveryDriverResponseDto> driverPage = deliveryDriverService.getDrivers(request, userId, role);
         return ResponseEntity.ok(DeliveryDriverResponseMapper.toPageListResponse(driverPage));
     }
 
@@ -69,9 +72,10 @@ public class DeliveryDriverController {
     @GetMapping("/{deliveryDriverId}")
     public ResponseEntity<DeliveryDriverDetailResponseDto> getDeliveryDriverDetail(
         @PathVariable Long deliveryDriverId,
-        @RequestHeader("X-client-userId") Long userId) {
+        @RequestHeader("X-client-userId") Long userId,
+        @RequestHeader("X-client-role") String role) {
 
-        DeliveryDriverDetailResponseDto response = deliveryDriverService.getDriverByDriverId(deliveryDriverId, userId);
+        DeliveryDriverDetailResponseDto response = deliveryDriverService.getDriverByDriverId(deliveryDriverId, userId, role);
         return ResponseEntity.ok(response);
     }
 
@@ -80,10 +84,11 @@ public class DeliveryDriverController {
     public ResponseEntity<DriverStatusUpdateResponseDto> updateDriverStatus(
         @PathVariable("deliveryRouteId") UUID deliveryRouteId,
         @RequestBody StatusUpdateRequestDto request,
-        @RequestHeader("X-client-userId") Long userId) {
+        @RequestHeader("X-client-userId") Long userId,
+        @RequestHeader("X-client-role") String role) {
 
         DriverStatusUpdateResponseDto response =
-            deliveryDriverService.updateDriverStatus(deliveryRouteId, request, userId);
+            deliveryDriverService.updateDriverStatus(deliveryRouteId, request, userId, role);
         return ResponseEntity.ok(response);
     }
 
@@ -91,9 +96,10 @@ public class DeliveryDriverController {
     @PatchMapping("/{deliveryRouteId}/cancel")
     public ResponseEntity<Void> cancelDriverStatus(
         @PathVariable("deliveryRouteId") UUID deliveryRouteId,
-        @RequestHeader("X-client-userId") Long userId) {
+        @RequestHeader("X-client-userId") Long userId,
+        @RequestHeader("X-client-role") String role) {
 
-        deliveryDriverService.cancelDriverStatus(deliveryRouteId, userId);
+        deliveryDriverService.cancelDriverStatus(deliveryRouteId, userId, role);
         return ResponseEntity.ok().build();
     }
 }

--- a/user/src/test/java/com/business/user/deliverydriver/application/service/DeliveryDriverServiceCancelTest.java
+++ b/user/src/test/java/com/business/user/deliverydriver/application/service/DeliveryDriverServiceCancelTest.java
@@ -29,6 +29,7 @@ class DeliveryDriverServiceCancelTest {
     private UUID deliveryRouteId;
     private DeliveryDriver deliveryDriver;
     private final Long userId = 1L;
+    private final String role = "ROLE_HUB";
 
     @BeforeEach
     void setUp() throws Exception {
@@ -53,7 +54,7 @@ class DeliveryDriverServiceCancelTest {
         when(deliveryDriverRepository.findByDeliveryRouteId(deliveryRouteId))
             .thenReturn(Optional.of(deliveryDriver));
 
-        deliveryDriverService.cancelDriverStatus(deliveryRouteId, userId);
+        deliveryDriverService.cancelDriverStatus(deliveryRouteId, userId, role);
 
         assertEquals(DriverStatus.CANCELED, deliveryDriver.getDriverStatus());
         verify(deliveryDriverRepository, times(1)).save(deliveryDriver);
@@ -64,7 +65,8 @@ class DeliveryDriverServiceCancelTest {
         when(deliveryDriverRepository.findByDeliveryRouteId(deliveryRouteId))
             .thenReturn(Optional.empty());
 
-        assertThrows(BusinessLogicException.class,
-            () -> deliveryDriverService.cancelDriverStatus(deliveryRouteId, userId));
+        assertThrows(BusinessLogicException.class, () -> {
+            deliveryDriverService.cancelDriverStatus(deliveryRouteId, userId, role);
+        });
     }
 }

--- a/user/src/test/java/com/business/user/deliverydriver/application/service/DeliveryDriverServiceStatusTest.java
+++ b/user/src/test/java/com/business/user/deliverydriver/application/service/DeliveryDriverServiceStatusTest.java
@@ -32,6 +32,7 @@ class DeliveryDriverServiceStatusTest {
     private UUID deliveryRouteId;
     private DeliveryDriver driver;
     private final Long userId = 1L;
+    private final String role = "ROLE_HUB";
 
     @BeforeEach
     void setUp() {
@@ -60,7 +61,7 @@ class DeliveryDriverServiceStatusTest {
         when(deliveryDriverRepository.save(any(DeliveryDriver.class)))
             .thenAnswer(invocation -> invocation.getArgument(0));
 
-        DriverStatusUpdateResponseDto responseDto = deliveryDriverService.updateDriverStatus(deliveryRouteId, request, userId);
+        DriverStatusUpdateResponseDto responseDto = deliveryDriverService.updateDriverStatus(deliveryRouteId, request, userId, role);
 
         assertEquals(DriverStatus.IN_TRANSIT_TO_HUB, responseDto.getDriverStatus());
         assertEquals(driver.getDeliveryDriverId(), responseDto.getDeliveryDriverId());
@@ -86,7 +87,7 @@ class DeliveryDriverServiceStatusTest {
             .thenReturn(Optional.of(driver));
 
         assertThrows(BusinessLogicException.class, () -> {
-            deliveryDriverService.updateDriverStatus(deliveryRouteId, request, userId);
+            deliveryDriverService.updateDriverStatus(deliveryRouteId, request, userId, role);
         });
     }
 
@@ -100,7 +101,7 @@ class DeliveryDriverServiceStatusTest {
             .thenReturn(Optional.empty());
 
         assertThrows(BusinessLogicException.class, () -> {
-            deliveryDriverService.updateDriverStatus(deliveryRouteId, request, userId);
+            deliveryDriverService.updateDriverStatus(deliveryRouteId, request, userId, role);
         });
     }
 }


### PR DESCRIPTION
## 개요
권한 체크를 위한 사용자 정보 헤더(userId, role) 추가

<br>

## 📝 작업 내용
### 변경 사항
- 모든 FeignClient 호출에 @RequestHeader("X-client-userId"), @RequestHeader("X-client-role") 추가
- Controller 레이어에서 userId, role 파라미터 수신하도록 통일
- Service 계층에서 userId 및 role 기반 권한 처리 로직 추가
- 테스트 코드에도 role  반영

### 변경 이유

### 추가 설명

<br>

### 💬리뷰 요구사항

<br>

### #️⃣ 연관된 이슈
closed #267

<br>

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [X] 새로운 기능 추가
- [X] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

<br>

## ✅ Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.
